### PR TITLE
Implement get_volumes_bulk_by_id

### DIFF
--- a/viperpy/api/block/volumes.py
+++ b/viperpy/api/block/volumes.py
@@ -26,6 +26,17 @@ class Volumes():
         json_data = self.conn.get('block/volumes/bulk')
         return json_data['id']
 
+    def get_volumes_bulk_by_id(self, volume_ids):
+        """
+        Retrieve detailed information about a set of volumes
+
+        :param volume_ids: A list of volume IDs
+        :return: A list of volumes
+        """
+        json_data = self.conn.post(url='block/volumes/bulk',
+                                   json_payload={"id": volume_ids})
+        return json_data['volume']
+
     def get_volume(self, volume_id):
         """
         Perform an HTTP GET against the ViPR endpoint to


### PR DESCRIPTION
Here's another one!

This is the implementation of [POST /block/volumes/bulk](http://www.emc.com/techpubs/api/vipr/v2-2-0-4/BlockService_getBulkResources_63927d26666a9525e638301030078b1a_ca374f6813ae52fdd5c80166d4b2e53e_detail.htm)

This call drastically reduces the time required to fetch ALL volume details:

``` python
# Get the volume IDs
vols = client.block_volumes.get_volumes_bulk()
# Old, slow way
vol_details = [client.block_volumes.get_volume(x) for x in vols] 
# New way, faster way
vols_details2 = client.block_volumes.get_volumes_bulk_by_id(vols)
```
