### PR TITLE
Add basic support for block virtual pools

### DIFF
--- a/viperpy/__init__.py
+++ b/viperpy/__init__.py
@@ -34,6 +34,7 @@ from viperpy.api.tenant.projects import Projects
 from viperpy.api.tenant.tenants import Tenants
 
 from viperpy.api.block.volumes import Volumes
+from viperpy.api.block.vpools import VirtualPools
 from viperpy.api.license import License
 
 from viperpy.util.exceptions import ViperpyException
@@ -121,6 +122,7 @@ class Viperpy(object):
 
         # API -> Block Volumes
         self.block_volumes = Volumes(self)
+        self.block_vpools = VirtualPools(self)
 
         # API -> License
         self.license = License(self)

--- a/viperpy/api/block/vpools.py
+++ b/viperpy/api/block/vpools.py
@@ -1,0 +1,47 @@
+# Standard lib imports
+# None
+
+# Third party imports
+# None
+
+# Project level imports
+# None
+
+
+class VirtualPools():
+
+    def __init__(self, connection):
+        """
+        Initialize a new instance
+        """
+        self.conn = connection
+
+    def get_vpools_bulk(self):
+        """
+        Perform an HTTP GET against the ViPR endpoint to
+        retrieve the block vpools bulk payload
+
+        :return: A list of vpools IDs
+        """
+        json_data = self.conn.get('block/vpools/bulk')
+        return json_data['id']
+
+    def get_vpools_bulk_by_id(self, vpool_ids):
+        """
+        Retrieve detailed information about a set of vpools
+
+        :param vpool_ids: A list of vpool IDs
+        :return: A list of vpools
+        """
+        json_data = self.conn.post(url='block/vpools/bulk',
+                                   json_payload={"id": vpool_ids})
+        return json_data['block_vpool']
+
+    def get_vpool(self, vpool_id):
+        """
+        Perform an HTTP GET against the ViPR endpoint to
+        retrieve the block vpool's information
+
+        :return: The block vpool's information
+        """
+        return self.conn.get('block/vpools/{0}'.format(vpool_id))


### PR DESCRIPTION
This adds the `viperpy.block_vpools` property, which can be used to query block vpools.

Ref: http://www.emc.com/techpubs/api/vipr/v2-2-0-4/BlockVirtualPoolService_ca374f6813ae52fdd5c80166d4b2e53e_overview.htm
